### PR TITLE
Add support for generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 Derive builders for your structs.
 
-The `#[derive(StructBuilder)]` macro creates new structs that can be used to build the struct being derived from that follow the builder pattern.
-The builder can be used to create the struct from only required fields (those without the `Option` type) and modify the content of the struct.
+Put `#[derive(StructBuilder)]` on your structs to derive a builder pattern for that struct. The builder
+can be used to create the struct from only required fields (those without the `Option` type) and modify
+the content of the struct.
 
-A struct builder enforces required fields to be specified and allows optional arguments to be specified post-construction.
-This is done by defining a "params" struct that the builder depends on to be initialized. This struct defines all the fields
-in the original struct that don't have the "Option" type. Once the builder is initialized with the params, both required and optional fields
-can be updated by calling builder methods (using the identifiers `with_<field>`).
+A struct builder enforces required fields to be specified and allows optional arguments to be specified
+post-construction. This is done by defining a "params" struct that the builder depends on to be initialized.
+This struct defines all the fields in the original struct that don't have the "Option" type. Once the builder
+is initialized with the params, both required and optional fields can be updated by calling builder methods
+(using the identifiers `with_<field>`).
 
 # Examples
 
@@ -24,9 +26,13 @@ pub struct CreateUserRequest {
 }
 
 fn main() {
+    // New "params" struct that defines required fields for [CreateUserRequest].
     let params = CreateUserRequestParams {
         email: "john.doe@email.com".to_owned()
     };
+    
+    // Create a builder using the [builder] function by passing the params to it.
+    // All optional fields are set to [None] by default.
     let request = CreateUserRequest::builder(params)
         .with_first_name(Some("John".to_owned()))
         .with_age(Some(35))

--- a/src/components/impl_from_builder_for_subject.rs
+++ b/src/components/impl_from_builder_for_subject.rs
@@ -1,0 +1,112 @@
+use crate::struct_builder::{BuilderContext, GenericsContext};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{parse_quote, Fields, ItemImpl, ItemStruct};
+
+pub struct ImplFromBuilderForSubject {
+    ctx: BuilderContext,
+    unit: bool
+}
+
+impl From<&ItemStruct> for ImplFromBuilderForSubject {
+    fn from(value: &ItemStruct) -> Self {
+        let ctx: BuilderContext = value.into();
+        let unit = matches!(&value.fields, Fields::Unit);
+
+        Self { ctx, unit }
+    }
+}
+
+impl ToTokens for ImplFromBuilderForSubject {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let BuilderContext {
+            subject,
+            builder,
+            builder_subject_field,
+            generics,
+            ..
+        } = &self.ctx;
+        let GenericsContext {
+            generics_def,
+            generics_expr,
+            where_clause
+        } = &generics;
+
+        if !self.unit {
+            let item_impl: ItemImpl = parse_quote! {
+                impl #generics_def From<#builder #generics_expr> for #subject #generics_expr #where_clause {
+                    fn from(value: #builder #generics_expr) -> Self {
+                        value.#builder_subject_field
+                    }
+                }
+            };
+
+            item_impl.to_tokens(tokens);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::components::{ImplFromParamsForSubject, ImplFromBuilderForSubject};
+    use crate::test_util::{sample_named_item_struct, sample_unit_item_struct, sample_unnamed_item_struct};
+    use proc_macro2::TokenStream;
+    use quote::ToTokens;
+    use syn::{parse_quote, ItemImpl};
+
+    #[test]
+    fn test_with_named_fields() {
+        let item_struct = sample_named_item_struct();
+        let expected: ItemImpl = parse_quote! {
+            impl<T, I: Send, W> From<MyStructBuilder<T, I, W>> for MyStruct<T, I, W>
+            where
+                W: Sync
+            {
+                fn from(value: MyStructBuilder<T, I, W>) -> Self {
+                    value.inner
+                }
+            }
+        };
+
+        let impl_from_builder_for_subject = ImplFromBuilderForSubject::from(&item_struct);
+
+        assert_eq!(
+            impl_from_builder_for_subject.to_token_stream().to_string(),
+            expected.to_token_stream().to_string()
+        );
+    }
+
+    #[test]
+    fn test_with_unnamed_fields() {
+        let item_struct = sample_unnamed_item_struct();
+        let expected: ItemImpl = parse_quote! {
+            impl<T, I: Send, W> From<MyStructBuilder<T, I, W>> for MyStruct<T, I, W>
+            where
+                W: Sync
+            {
+                fn from(value: MyStructBuilder<T, I, W>) -> Self {
+                    value.inner
+                }
+            }
+        };
+
+        let impl_from_builder_for_subject = ImplFromBuilderForSubject::from(&item_struct);
+
+        assert_eq!(
+            impl_from_builder_for_subject.to_token_stream().to_string(),
+            expected.to_token_stream().to_string()
+        );
+    }
+
+    #[test]
+    fn test_with_unit_struct() {
+        let item_struct = sample_unit_item_struct();
+
+        let subject_impl = ImplFromParamsForSubject::from(&item_struct);
+
+        assert_eq!(
+            subject_impl.to_token_stream().to_string(),
+            TokenStream::new().to_string()
+        );
+    }
+}

--- a/src/components/impl_subject_fn_builder.rs
+++ b/src/components/impl_subject_fn_builder.rs
@@ -5,16 +5,16 @@ use syn::punctuated::Punctuated;
 use syn::{parse_quote, Expr, Field, FieldValue, Fields, Index, ItemImpl, ItemStruct, Token, Type};
 
 pub struct ImplSubjectFnBuilder {
-    idents: BuilderContext,
+    ctx: BuilderContext,
     fields: Fields
 }
 
 impl From<&ItemStruct> for ImplSubjectFnBuilder {
     fn from(value: &ItemStruct) -> Self {
-        let idents = BuilderContext::from(value);
+        let ctx = BuilderContext::from(value);
         let fields = value.fields.clone();
         
-        Self { idents, fields }
+        Self { ctx: ctx, fields }
     }
 }
 
@@ -26,8 +26,9 @@ impl ToTokens for ImplSubjectFnBuilder {
             params_argument,
             builder,
             builder_subject_field,
-            generics
-        } = &self.idents;
+            generics,
+            ..
+        } = &self.ctx;
         
         let optional_expr: Option<Expr> = match &self.fields {
             Fields::Named(named_fields) => {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,6 +2,7 @@ mod impl_subject_fn_builder;
 mod params_struct;
 mod builder_struct;
 mod impl_builder_fns;
+mod impl_from_builder_for_subject;
 mod impl_from_params_for_subject;
 mod impl_from_subject_for_builder;
 
@@ -9,5 +10,6 @@ pub use impl_subject_fn_builder::*;
 pub use params_struct::*;
 pub use builder_struct::*;
 pub use impl_builder_fns::*;
+pub use impl_from_builder_for_subject::*;
 pub use impl_from_params_for_subject::*;
 pub use impl_from_subject_for_builder::*;

--- a/src/generic_resolution.rs
+++ b/src/generic_resolution.rs
@@ -1,0 +1,136 @@
+use proc_macro2::Ident;
+use syn::punctuated::Punctuated;
+use syn::{Field, GenericParam, Generics, ReturnType, Token, Type};
+
+struct SearchIdents {
+    types: Vec<Ident>,
+    lifetimes: Vec<Ident>
+}
+
+#[inline]
+pub fn field_has_generic(generics: &Generics, field: &Field) -> bool {
+    generic_params_contain_type(&generics.params, &field.ty)
+}
+
+fn generic_params_contain_type(generic_params: &Punctuated<GenericParam, Token![,]>, ty: &Type) -> bool {
+    let mut search_idents = SearchIdents {
+        types: vec![],
+        lifetimes: vec![],
+    };
+
+    for param in generic_params {
+        match param {
+            GenericParam::Lifetime(lp) => search_idents.lifetimes.push(lp.lifetime.ident.clone()),
+            GenericParam::Type(tp) => search_idents.types.push(tp.ident.clone()),
+            GenericParam::Const(cp) => search_idents.types.push(cp.ident.clone())
+        }
+    }
+
+    search_idents_contain_type(&search_idents, &ty)
+}
+
+fn search_idents_contain_type(search_idents: &SearchIdents, ty: &Type) -> bool {
+    #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
+    match ty {
+        Type::Array(array) => search_idents_contain_type(&search_idents, &array.elem),
+
+        Type::BareFn(bare_fn) => {
+            let mut contains = false;
+            if let Some(lts) = &bare_fn.lifetimes {
+                contains = contains || generic_params_contain_type(&lts.lifetimes, &ty)
+            }
+            for input in &bare_fn.inputs {
+                contains = contains || search_idents_contain_type(&search_idents, &input.ty)
+            }
+            if let ReturnType::Type(_, inner_ty) = &bare_fn.output {
+                contains = contains || search_idents_contain_type(&search_idents, &inner_ty);
+            }
+            contains
+        }
+
+        Type::Group(group) => search_idents_contain_type(&search_idents, &group.elem),
+
+        Type::Paren(paren) => search_idents_contain_type(&search_idents, &paren.elem),
+
+        Type::Path(path) => {
+            if let Some(qself) = &path.qself {
+                search_idents_contain_type(&search_idents, &qself.ty)
+            } else {
+                let p = &path.path;
+                search_idents.types.iter().any(|ty| p.is_ident(ty))
+            }
+        },
+
+        Type::Ptr(ptr) => search_idents_contain_type(&search_idents, &ptr.elem),
+
+        Type::Reference(reference) => {
+            let mut contains = false;
+            
+            if let Some(lt) = &reference.lifetime {
+                contains = contains || search_idents.lifetimes.contains(&lt.ident)
+            }
+            
+            contains || search_idents_contain_type(&search_idents, &reference.elem)
+        },
+
+        Type::Slice(slice) => search_idents_contain_type(&search_idents, &slice.elem),
+        
+        Type::Tuple(tuple) => tuple.elems.iter().any(|el| search_idents_contain_type(&search_idents, &el)),
+
+        // todo - unknown
+        Type::ImplTrait(_) => false,
+
+        // todo - unknown
+        Type::TraitObject(_) => false,
+
+        _ => false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::generic_resolution::field_has_generic;
+    use syn::{parse_quote, Field, Generics};
+
+    macro_rules! test_cases {
+        ($($name:tt| $generics:tt | $field:tt |$res:literal),*$(,)?) => {
+            $(
+                #[test]
+                fn $name() {
+                    let generics: Generics = parse_quote! $generics ;
+                    let field: Field = parse_quote! $field ;
+                    
+                    assert_eq!(field_has_generic(&generics, &field), $res);
+                }
+            )*
+        };
+    }
+    
+    test_cases! {
+        test_array_no_generics |{      }|{ values: [A; 3]  }| false,
+        test_array_has_type    |{ <T>  }|{ values: [T; 2]       }| true,
+        test_array_has_liftime |{ <'a> }|{ values: [&'a B; 1] }| true,
+        
+        test_bare_fn_no_generics        |{      }|{ block: fn(B) -> u64         }| false,
+        test_bare_fn_has_input_type     |{ <T>  }|{ block: fn(T) -> u64         }| true,
+        test_bare_fn_has_output_type    |{ <T>  }|{ block: fn(u32) -> T         }| true,
+        test_bare_fn_has_input_liftime  |{ <'a> }|{ block: fn(&'a str) -> usize }| true,
+        test_bare_fn_has_output_liftime |{ <'a> }|{ block: fn() -> &'a str      }| true,
+        
+        test_paren_no_generics |{      }|{ value: (String)  }| false,
+        test_paren_has_type    |{ <T>  }|{ value: (T)       }| true,
+        test_paren_has_liftime |{ <'a> }|{ value: (&'a str) }| true,
+        
+        test_path_no_generics        |{      }|{ value: ::std::option::Option<A> }| false,
+        test_path_qself_has_type     |{ <T>  }|{ value: <T>::Type                }| true,
+        test_path_qself_has_lifetime |{ <'a> }|{ value: <&'a Self as Send>::Type }| true,
+        test_path_has_type           |{ <T>  }|{ value: T                        }| true,
+        
+        test_ptr_no_generics  |{      }|{ value: *const A }| false,
+        test_ptr_has_type     |{ <T>  }|{ value: *mut T   }| true,
+        
+        test_reference_no_generics  |{      }|{ value: &'static A }| false,
+        test_reference_has_type     |{ <T>  }|{ value: &'static T }| false,
+        test_reference_has_lifetime |{ <'a> }|{ value: &'a T      }| false,
+    }
+}

--- a/src/generic_resolution.rs
+++ b/src/generic_resolution.rs
@@ -130,7 +130,15 @@ mod tests {
         test_ptr_has_type     |{ <T>  }|{ value: *mut T   }| true,
         
         test_reference_no_generics  |{      }|{ value: &'static A }| false,
-        test_reference_has_type     |{ <T>  }|{ value: &'static T }| false,
-        test_reference_has_lifetime |{ <'a> }|{ value: &'a T      }| false,
+        test_reference_has_type     |{ <T>  }|{ value: &'static T }| true,
+        test_reference_has_lifetime |{ <'a> }|{ value: &'a T      }| true,
+        
+        test_slice_no_generics  |{      }|{ value: &'static [A] }| false,
+        test_slice_has_type     |{ <T>  }|{ value: &'static [T] }| true,
+        test_slice_has_lifetime |{ <'a> }|{ value: &'a [A]      }| true,
+        
+        test_tuple_no_generics  |{      }|{ value: (A, B, C)  }| false,
+        test_tuple_has_type     |{ <T>  }|{ value: (A, B, T)  }| true,
+        test_tuple_has_lifetime |{ <'a> }|{ value: (&'a A, B) }| true,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,9 +112,9 @@ extern crate proc_macro;
 
 mod components;
 mod struct_builder;
+mod generic_resolution;
 #[cfg(test)]
 mod test_util;
-mod generic_resolution;
 
 use quote::quote;
 use syn::{parse_macro_input, ItemStruct};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! Derive builders for your structs.
 //! 
-//! The derive macro [StructBuilder] creates new structs that can be used to build the struct being derived from that follow the builder pattern.
-//! The builder can be used to create the struct from only required fields (those without the [Option] type) and modify the content of the struct.
+//! Putting `#[derive(StructBuilder)]` on your struct will derive the builder pattern for it. A new "params" struct will be defined 
+//! derived from that follow the builder pattern. The builder can be used to create the struct from only
+//! required fields (those without the [Option] type) and modify the content of the struct.
 //!
 //! A struct builder enforces required fields to be specified and allows optional arguments to be specified post-construction.
 //! This is done by defining a "params" struct that the builder depends on to be initialized. This struct defines all the fields
@@ -93,7 +94,7 @@
 //! let rebuilt_request = CreateUserRequestBuilder::from(request)
 //!     .with_last_name(Some("Doe".to_owned()))
 //!     .build();
-//! 
+//!
 //! assert_eq!(rebuilt_request.email, "john.doe@email.com".to_owned());
 //! assert_eq!(rebuilt_request.first_name, Some("John".to_owned()));
 //! assert_eq!(rebuilt_request.last_name, Some("Doe".to_owned()));
@@ -103,6 +104,9 @@ extern crate proc_macro;
 
 mod components;
 mod struct_builder;
+#[cfg(test)]
+mod test_util;
+mod generic_resolution;
 
 use quote::quote;
 use syn::{parse_macro_input, ItemStruct};

--- a/src/struct_builder.rs
+++ b/src/struct_builder.rs
@@ -1,7 +1,7 @@
+use crate::components::{BuilderStruct, ImplBuilderFns, ImplFromBuilderForSubject, ImplFromParamsForSubject, ImplFromSubjectForBuilder, ImplSubjectFnBuilder, ParamsStruct};
 use proc_macro2::TokenStream;
 use quote::{format_ident, ToTokens};
 use syn::{parse_quote, GenericParam, Generics, Ident, ItemStruct, TypeParam};
-use crate::components::{BuilderStruct, ImplBuilderFns, ImplFromParamsForSubject, ImplFromSubjectForBuilder, ImplSubjectFnBuilder, ParamsStruct};
 
 const PARAMS_ARGUMENT_NAME: &str = "params";
 const BUILDER_SUBJECT_FIELD_NAME: &str = "inner";
@@ -14,13 +14,37 @@ pub struct BuilderContext {
     pub params_argument: Ident,
     pub builder: Ident,
     pub builder_subject_field: Ident,
-    pub generics: Generics
+    pub generics: GenericsContext,
+    pub fields_metadata: FieldsMetadata
+}
+
+pub struct FieldsMetadata {
+    required_fields_count: usize,
+    optional_fields_count: usize,
+    generic_required_fields_count: usize,
+    generic_optional_fields_count: usize
 }
 
 pub struct GenericsContext {
     generics_def: Generics,
     generics_expr: Generics,
     where_expr: Generics
+}
+
+impl From<&ItemStruct> for FieldsMetadata {
+    fn from(value: &ItemStruct) -> Self {
+        let mut meta = Self {
+            required_fields_count: 0,
+            optional_fields_count: 0,
+            generic_required_fields_count: 0,
+            generic_optional_fields_count: 0,
+        };
+        
+        for field in &value.fields {
+        }
+        
+        meta
+    }
 }
 
 impl From<&ItemStruct> for BuilderContext {
@@ -31,7 +55,8 @@ impl From<&ItemStruct> for BuilderContext {
             params_argument: format_ident!("{}", PARAMS_ARGUMENT_NAME),
             builder: format_ident!("{}Builder", &item.ident),
             builder_subject_field: format_ident!("{}", BUILDER_SUBJECT_FIELD_NAME),
-            generics: item.generics.clone()
+            generics: GenericsContext::from(&item.generics),
+            fields_metadata: FieldsMetadata::from(item)
         }
     }
 }
@@ -42,11 +67,17 @@ impl From<&Generics> for GenericsContext {
         generics_def.where_clause = None;
 
         let mut generics_expr = value.clone();
-        // generics_expr.params.into_iter().map(|p| match p {
-        //     GenericParam::Lifetime(_) => todo!(),
-        //     GenericParam::Type(TypeParam { ident, .. }) => parse_quote! { #ident }),
-        //     GenericParam::Const(_) => panic!("not supported!")
-        // })
+        generics_expr.params.into_iter().map(|p| match p {
+            GenericParam::Lifetime(_) => todo!(),
+            GenericParam::Type(TypeParam { ident, .. }) => parse_quote! { #ident }),
+            GenericParam::Const(_) => panic!("not supported!")
+        })
+    }
+}
+
+impl BuilderContext {
+    pub fn are_params_generic(&self) -> bool {
+        self.fields_metadata.generic_required_fields_count > 0
     }
 }
 
@@ -59,6 +90,7 @@ impl ToTokens for StructBuilder {
             Box::new(ParamsStruct::from(item)),
             Box::new(BuilderStruct::from(item)),
             Box::new(ImplBuilderFns::from(item)),
+            Box::new(ImplFromBuilderForSubject::from(item)),
             Box::new(ImplFromParamsForSubject::from(item)),
             Box::new(ImplFromSubjectForBuilder::from(item)),
         ];

--- a/tests/named_struct_builder.rs
+++ b/tests/named_struct_builder.rs
@@ -1,29 +1,51 @@
 use struct_builder::StructBuilder;
 
 #[derive(StructBuilder)]
-pub struct Platypus<T> {
+pub struct Platypus<S>
+where
+    S: Into<String>
+{
     pub age: u8,
     pub color: (u8, u8, u8),
-    pub name: Option<String>,
-    pub is_perry: T
+    pub name: Option<S>,
+    pub is_perry: bool
 }
 
 #[test]
-fn test_named_struct_builder() {
-    let params: PlatypusParams<bool> = PlatypusParams {
+fn test_structs_are_defined() {
+    let params = PlatypusParams {
         age: 3,
         color: (36, 167, 161),
         is_perry: false
     };
 
     let platypus = Platypus::builder(params)
-        .with_name(Some(String::from("Perry")))
+        .with_name(Some("Perry"))
         .with_age(4)
         .with_is_perry(true)
         .build();
     
     assert_eq!(platypus.age, 4);
     assert_eq!(platypus.color, (36, 167, 161));
-    assert_eq!(platypus.name, Some(String::from("Perry")));
-    assert_eq!(platypus.is_perry, Some(true));
+    assert_eq!(platypus.name, Some("Perry"));
+    assert_eq!(platypus.is_perry, true);
+}
+
+#[test]
+fn test_subject_from_params() {
+    let params = PlatypusParams {
+        age: 0,
+        color: (0, 0, 0),
+        is_perry: ,
+    };
+}
+
+#[test]
+fn test_subject_from_builder() {
+    
+}
+
+#[test]
+fn test_builder_from_subject() {
+    
 }

--- a/tests/named_struct_builder.rs
+++ b/tests/named_struct_builder.rs
@@ -34,10 +34,17 @@ fn test_structs_are_defined() {
 #[test]
 fn test_subject_from_params() {
     let params = PlatypusParams {
-        age: 0,
-        color: (0, 0, 0),
-        is_perry: ,
+        age: 2,
+        color: (1, 2, 3),
+        is_perry: false,
     };
+    
+    let subject: Platypus<&'static str> = params.into();
+
+    assert_eq!(subject.age, 2);
+    assert_eq!(subject.color, (1, 2, 3));
+    assert_eq!(subject.name, None);
+    assert_eq!(subject.is_perry, false);
 }
 
 #[test]


### PR DESCRIPTION
Add support for generics for the `#[derive(StructBuilder)]` macro.