### PR TITLE
Create new attribute macro to support attribute inheritence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "struct-builder"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Derive builders for your structs.
 
-Put `#[derive(StructBuilder)]` on your structs to derive a builder pattern for that struct. The builder
+Put `#[builder]` on your structs to derive a builder pattern for that struct. The builder
 can be used to create the struct from only required fields (those without the `Option` type) and modify
 the content of the struct.
 
@@ -12,32 +12,33 @@ is initialized with the params, both required and optional fields can be updated
 
 # Examples
 
-## Using StructBuilder to build a request with named fields.
+Using `builder` to build a request with named fields.
 
 ```rust
-use struct_builder::StructBuilder;
+use struct_builder::builder;
 
-#[derive(StructBuilder)]
-pub struct CreateUserRequest {
+#[builder]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CreateUserRequest<P> {
     pub email: String,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
-    pub age: Option<u64>
+    pub age: Option<u64>,
+    pub payload: P
 }
 
 fn main() {
-    // New "params" struct that defines required fields for [CreateUserRequest].
-    let params = CreateUserRequestParams {
-        email: "john.doe@email.com".to_owned()
+    // Inherits attributes and generics from `CreateUserRequest`
+    let params: CreateUserRequestParams<String> = CreateUserRequestParams {
+        email: "john.doe@email.com".to_owned(),
+        payload: "John Doe's User".to_owned()
     };
-    
-    // Create a builder using the [builder] function by passing the params to it.
-    // All optional fields are set to [None] by default.
+
     let request = CreateUserRequest::builder(params)
         .with_first_name(Some("John".to_owned()))
         .with_age(Some(35))
         .build();
-
+    
     assert_eq!(request.email, "john.doe@email.com".to_owned());
     assert_eq!(request.first_name, Some("John".to_owned()));
     assert_eq!(request.last_name, None);

--- a/src/generic_resolution.rs
+++ b/src/generic_resolution.rs
@@ -30,7 +30,6 @@ fn generic_params_contain_type(generic_params: &Punctuated<GenericParam, Token![
 }
 
 fn search_idents_contain_type(search_idents: &SearchIdents, ty: &Type) -> bool {
-    #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
     match ty {
         Type::Array(array) => search_idents_contain_type(&search_idents, &array.elem),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Derive builders for your structs.
 //! 
-//! Putting `#[derive(StructBuilder)]` on your struct will derive the builder pattern for it. A new "params" struct will be defined 
+//! Putting `#[builder]` on your struct will derive the builder pattern for it. A new "params" struct will be defined 
 //! derived from that follow the builder pattern. The builder can be used to create the struct from only
 //! required fields (those without the [Option] type) and modify the content of the struct.
 //!
@@ -9,19 +9,14 @@
 //! in the original struct that don't have the "Option" type. Once the builder is initialized with the params, both required and optional fields
 //! can be updated by calling builder methods (using the identifiers `with_<field>`).
 //!
-//! # Supported
-//!
-//! - [x] Generics (types, lifetime specifiers, const)
-//! - [ ] Attributes
-//! - [ ] ... (TBD)
-//!
 //! # Examples
 //!
-//! ## Using [derive@StructBuilder] to build a request with named fields.
+//! ## Using [builder] to build a request with named fields.
 //! ```
-//! use struct_builder::StructBuilder;
+//! use struct_builder::builder;
 //!
-//! #[derive(StructBuilder)]
+//! #[builder]
+//! #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 //! pub struct CreateUserRequest<P> {
 //!     pub email: String,
 //!     pub first_name: Option<String>,
@@ -30,10 +25,12 @@
 //!     pub payload: P
 //! }
 //!
-//! let params = CreateUserRequestParams {
+//! // Inherits attributes and generics from `CreateUserRequest`
+//! let params: CreateUserRequestParams<String> = CreateUserRequestParams {
 //!     email: "john.doe@email.com".to_owned(),
 //!     payload: "John Doe's User".to_owned()
 //! };
+//!
 //! let request = CreateUserRequest::builder(params)
 //!     .with_first_name(Some("John".to_owned()))
 //!     .with_age(Some(35))
@@ -45,15 +42,16 @@
 //! assert_eq!(request.age, Some(35));
 //! ```
 //!
-//! ## Using [derive@StructBuilder] to build a tuple (unnamed) struct.
+//! ## Using [builder] to build a tuple (unnamed) struct.
 //! ```
-//! use struct_builder::StructBuilder;
+//! use struct_builder::builder;
 //!
 //! /// First, Middle, and Last names.
-//! #[derive(StructBuilder)]
+//! #[builder]
 //! pub struct FullName(pub String, pub Option<String>, pub String);
 //!
 //! let params = FullNameParams("John".to_owned(), "Doe".to_owned());
+//!
 //! let request = FullName::builder(params)
 //!     .with_1(Some("Harold".to_owned()))
 //!     .build();
@@ -65,9 +63,9 @@
 //!
 //! ## Converting a params struct directly with no builder.
 //! ```
-//! use struct_builder::StructBuilder;
+//! use struct_builder::builder;
 //!
-//! #[derive(StructBuilder)]
+//! #[builder]
 //! pub struct CreateUserRequest {
 //!     pub email: String,
 //!     pub first_name: Option<String>,
@@ -85,9 +83,9 @@
 //!
 //! ## Creating a builder directly
 //! ```
-//! use struct_builder::StructBuilder;
+//! use struct_builder::builder;
 //!
-//! #[derive(StructBuilder)]
+//! #[builder]
 //! pub struct CreateUserRequest {
 //!     pub email: String,
 //!     pub first_name: Option<String>,
@@ -99,6 +97,7 @@
 //!     first_name: Some("John".to_owned()),
 //!     last_name: None
 //! };
+//!
 //! let rebuilt_request = CreateUserRequestBuilder::from(request)
 //!     .with_last_name(Some("Doe".to_owned()))
 //!     .build();
@@ -116,13 +115,23 @@ mod generic_resolution;
 #[cfg(test)]
 mod test_util;
 
+use crate::struct_builder::StructBuilder;
 use quote::quote;
 use syn::{parse_macro_input, ItemStruct};
-use crate::struct_builder::StructBuilder;
 
-/// Derive a struct builder for a struct.
-///
-///
+#[proc_macro_attribute]
+pub fn builder(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let original_item = parse_macro_input!(item as ItemStruct);
+    let struct_builder = StructBuilder(original_item.clone());
+
+    proc_macro::TokenStream::from(quote! { 
+        #original_item
+        #struct_builder
+    })
+}
+
+
+#[deprecated(since = "0.3.0", note = "Please use `#[builder]` macro instead")]
 #[proc_macro_derive(StructBuilder)]
 pub fn derive_builder(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let item = parse_macro_input!(item as ItemStruct);

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -2,6 +2,7 @@ use syn::{parse_quote, ItemStruct};
 
 pub fn sample_named_item_struct() -> ItemStruct {
     parse_quote! {
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
         pub struct MyStruct<T, I: Send, W>
         where
             W: Sync
@@ -9,10 +10,12 @@ pub fn sample_named_item_struct() -> ItemStruct {
             pub public_field: String,
             private_field: String,
             optional: Option<usize>,
+            #[serde(rename = "testMe")]
             pub test: std::option::Option<String>,
             test2: option::Option<T>,
             pub dynamic: Box<dyn Send>,
             pub dynamic2: Box<Option<dyn Send>>,
+            #[serde(rename = "simpleGeneric")]
             pub generic: T,
             pub generic_inline: I,
             pub generic_where: W
@@ -26,10 +29,12 @@ pub fn sample_unnamed_item_struct() -> ItemStruct {
             pub String,
             String,
             Option<usize>,
+            #[inline_optional]
             pub std::option::Option<String>,
             option::Option<T>,
             pub Box<dyn Send>,
             pub Box<Option<dyn Send>>,
+            #[inline_required]
             pub T,
             pub I,
             pub W

--- a/tests/named_struct_builder.rs
+++ b/tests/named_struct_builder.rs
@@ -1,14 +1,15 @@
-use struct_builder::StructBuilder;
+use struct_builder::builder;
 
-#[derive(StructBuilder)]
+#[builder]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Platypus<S>
 where
-    S: Into<String>
+    S: Into<String>,
 {
     pub age: u8,
     pub color: (u8, u8, u8),
     pub name: Option<S>,
-    pub is_perry: bool
+    pub is_perry: bool,
 }
 
 #[test]
@@ -16,7 +17,7 @@ fn test_structs_are_defined() {
     let params = PlatypusParams {
         age: 3,
         color: (36, 167, 161),
-        is_perry: false
+        is_perry: false,
     };
 
     let platypus = Platypus::builder(params)
@@ -24,7 +25,7 @@ fn test_structs_are_defined() {
         .with_age(4)
         .with_is_perry(true)
         .build();
-    
+
     assert_eq!(platypus.age, 4);
     assert_eq!(platypus.color, (36, 167, 161));
     assert_eq!(platypus.name, Some("Perry"));
@@ -38,7 +39,7 @@ fn test_subject_from_params() {
         color: (1, 2, 3),
         is_perry: false,
     };
-    
+
     let subject: Platypus<&'static str> = params.into();
 
     assert_eq!(subject.age, 2);
@@ -49,10 +50,50 @@ fn test_subject_from_params() {
 
 #[test]
 fn test_subject_from_builder() {
-    
+    let builder = Platypus::builder(
+        PlatypusParams {
+            age: 2,
+            color: (1, 2, 3),
+            is_perry: false,
+        })
+        .with_name(Some("perry"));
+
+    let subject: Platypus<&'static str> = builder.into();
+
+    assert_eq!(subject.age, 2);
+    assert_eq!(subject.color, (1, 2, 3));
+    assert_eq!(subject.name, Some("perry"));
+    assert_eq!(subject.is_perry, false);
 }
 
 #[test]
 fn test_builder_from_subject() {
+    let subject = Platypus {
+        age: 2,
+        color: (1, 2, 3),
+        name: Some("perry"),
+        is_perry: true
+    };
+
+    let builder: PlatypusBuilder<&str> = subject.into();
+
+    assert_eq!(builder.inner.age, 2);
+    assert_eq!(builder.inner.color, (1, 2, 3));
+    assert_eq!(builder.inner.name, Some("perry"));
+    assert_eq!(builder.inner.is_perry, true);   
+}
+
+#[test]
+fn test_params_has_attributes() {
+    let params = PlatypusParams {
+        age: 1,
+        color: (23, 45, 56),
+        is_perry: false,
+    };
     
+    // Test clone
+    let new_params = params.clone();
+    
+    // Test PartialEq
+    assert_eq!(params, new_params);
 }

--- a/tests/unnamed_struct_builder.rs
+++ b/tests/unnamed_struct_builder.rs
@@ -1,6 +1,6 @@
-use struct_builder::StructBuilder;
+use struct_builder::builder;
 
-#[derive(StructBuilder)]
+#[builder]
 pub struct Platypus<T>(
     pub u8,
     pub (u8, u8, u8),


### PR DESCRIPTION
Inherit existing outer attributes on a struct by defining the struct builder as a new attribute macro `#[builder]`.

Deprecate the derive macro `#[derive(StructBuilder)]`.